### PR TITLE
W.I.P

### DIFF
--- a/controllers/routes.js
+++ b/controllers/routes.js
@@ -24,4 +24,9 @@ router.put('/task/:id', (req, res, next) => {
   tasks.saveTask(req, res)
 })
 
+//UPDATE ONE
+router.put('/task/:id/', (req, res, next) => {
+  tasks.updateTask(req, res)
+})
+
 module.exports = router

--- a/db.js
+++ b/db.js
@@ -1,10 +1,8 @@
 const mongoose = require('mongoose')
-
 const async = require('async')
 var schema = require('./public/schemas/schema')
 var testSchema = new mongoose.Schema(schema)
 const testData = require('./test/testData')
-
 var append
 
 //SELECT ENVIRONMENT
@@ -61,8 +59,14 @@ let newModel = async(testTasks) => {
 }
 
 //SAVE NEW MODEL TO DB
-exports.saver = (tsk) => {
-  tsk.save( (err, res) => {
-    if (err){ return console.log("Custom testData/tsk.save message: "+err.errmsg) }
+exports.saver = async (tsk) => {
+  await tsk.save( (err, task) => {
+    if(err){ res.send(saveErrorMsg(err)) }
+    return task
   })
+}
+
+//SAVE FUNCTION ERR MESSAGE
+let saveErrorMsg = async (err) => {
+  return console.log("Custom testData/tsk.save message: "+err.errmsg)
 }

--- a/models/tasks.js
+++ b/models/tasks.js
@@ -46,10 +46,7 @@ exports.saveTask = async function(req, res) {
   await db.connect()
   let getParams = req.params
   let tsk = new Task({_id: getParams.id, task: getParams.task})
-  await tsk.save( (err, task) => {
-    if(err){return res.send("Custom saveTask err msg: "+err)}
-    res.send("SAVED: "+task)
-  }).catch(() => {})
+  res.send("SAVED: "+ await db.saver(tsk))
 }
 
 exports.updateTask = async function(req, res) {

--- a/test/unit.spec.js
+++ b/test/unit.spec.js
@@ -88,11 +88,10 @@ describe('DATABASE\n', async function() {
     })
   })
 
-  it('should recognise an attempt to save a document without an id', function() {
-    mockRequest(getTasks.saveTask)
-    .params({task: "This is a document without an id."})
-    .end(function(output) {
-      expect(output).to.equal('Custom saveTask err msg: Error: document must have an _id before saving')
+  it('should recognise an attempt to save a document without an id', async function() {
+    let y = { params: { task: 'This is a document without an id.' } }
+    await getTasks.saveTask( y, stubResponse ).catch((err) => {
+      expect(err.toString()).to.equal('Error: document must have an _id before saving')
     })
   })
 


### PR DESCRIPTION
DRY task.js by using db's save function rather than a local duplicate save function.
Extract db save function error message into own function.